### PR TITLE
Deprecate unused Sonar inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,8 @@ inputs:
     required: true
     default: ''
   sonar-tool-version:
-    description: 'Sonar tool version'
+    description: 'Deprecated — no longer has any effect.'
     required: false
-    default: '5.13.0'
   use-dependencies:
     description: 'Use Docker to run dependencies.'
     required: false
@@ -19,9 +18,8 @@ inputs:
     required: false
     default: 'docker-compose/test-dependencies-compose.yml'  
   sonar-token:
-    description: 'Sonar Token'
+    description: 'Deprecated — no longer has any effect.'
     required: false
-    default: ''
   path-to-repo-root:
     description: 'Path to Repo Root'
     required: false
@@ -39,20 +37,17 @@ inputs:
     required: false
     default: 'local.runsettings'
   upload-sonar-results:
-    description: 'Whether to upload Sonar results as an artifact'
+    description: 'Deprecated — no longer has any effect.'
     required: false
-    default: true
   fail-on-failure:
-    description: 'set to true if you wish to fail this run when the Quality Gate is red'
+    description: 'Deprecated — no longer has any effect.'
     required: false
-    default: true
   log-level:
     description: 'Log-level for dotnet test command. Default is quiet'
     default: 'quiet'
   ignore-failures:
-    description: 'Ignore Sonar Quality Gate. Set sonar'
+    description: 'Deprecated — no longer has any effect.'
     required: false
-    default: ''
   vulnerability_codes:
     description: 'Pipe delimited vulnerabilities to look for on build.log output'
     default: 'NU1902|NU1903|NU1904'
@@ -60,10 +55,20 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Warn deprecated Sonar inputs
+      shell: bash
+      run: |
+        [ -n "${{ inputs.sonar-token }}" ]          && echo "::notice::sonar-token is deprecated and has no effect — remove it from your workflow call."
+        [ -n "${{ inputs.sonar-tool-version }}" ]   && echo "::notice::sonar-tool-version is deprecated and has no effect — remove it from your workflow call."
+        [ -n "${{ inputs.upload-sonar-results }}" ] && echo "::notice::upload-sonar-results is deprecated and has no effect — remove it from your workflow call."
+        [ -n "${{ inputs.fail-on-failure }}" ]      && echo "::notice::fail-on-failure is deprecated and has no effect — remove it from your workflow call."
+        [ -n "${{ inputs.ignore-failures }}" ]      && echo "::notice::ignore-failures is deprecated and has no effect — remove it from your workflow call."
+        true
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0  # Disable shallow-clone so Sonar can do git-blame
+        fetch-depth: 0  # Disable shallow-clone so we can git-blame
     
 
     - name: Dotnet Coverage Install


### PR DESCRIPTION
## Summary
- Drops defaults from the five Sonar-specific inputs (`sonar-token`, `sonar-tool-version`, `upload-sonar-results`, `fail-on-failure`, `ignore-failures`) — none are consumed by any step after #24
- Updates their descriptions to "Deprecated — no longer has any effect."
- Adds a first step that emits a `::notice::` annotation for any deprecated input a caller still passes, so teams know to clean up their workflows
- Updates the `fetch-depth: 0` comment to remove the Sonar reference

## Test plan
- [ ] Verify a workflow that passes deprecated inputs sees notice annotations in the Actions UI
- [ ] Verify a workflow that passes no deprecated inputs sees no notices
- [ ] Verify normal test/coverage/vulnerability scan steps are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)